### PR TITLE
Refactor Build Application Status Row in Tests

### DIFF
--- a/scripts/round/setApplicationStatuses.ts
+++ b/scripts/round/setApplicationStatuses.ts
@@ -5,42 +5,18 @@ import hre from "hardhat";
 import { confirmContinue } from "../../utils/script-utils";
 import { roundParams } from "../config/round.config";
 import * as utils from "../utils";
+import { buildStatusRow, ApplicationStatus } from "../../utils/applicationStatus";
 
 utils.assertEnvironment();
 
-const STATUS = {
-  PENDING: 0,
-  ACCEPTED: 1,
-  REJECTED: 2,
-  CANCELED: 3,
-};
-
 const applicationStatusBitMapIndex = 0;
 
-const projectIndexes: number[] = [0, 1, 2, 3];
-const statusArray: number[] = [
-  STATUS.PENDING,
-  STATUS.ACCEPTED,
-  STATUS.REJECTED,
-  STATUS.CANCELED,
+const statuses = [
+  { index: 0, status: ApplicationStatus.PENDING },
+  { index: 1, status: ApplicationStatus.ACCEPTED },
+  { index: 2, status: ApplicationStatus.REJECTED },
+  { index: 3, status: ApplicationStatus.CANCELED },
 ];
-
-const buildNewState = (
-  current: bigint,
-  indexes: number[],
-  statusArray: number[]
-) => {
-  let newState: bigint = current;
-
-  for (let i = 0; i < indexes.length; i++) {
-    const index = indexes[i];
-    const position = (index % 32) * 2;
-    const mask = BigInt(~(BigInt(3) << BigInt(position)));
-    newState = (newState & mask) | (BigInt(statusArray[i]) << BigInt(position));
-  }
-
-  return newState.toString();
-};
 
 export async function main() {
   const network = hre.network;
@@ -67,10 +43,9 @@ export async function main() {
   const currentStatuses = await round.applicationStatusesBitMap(
     applicationStatusBitMapIndex
   );
-  const newState = buildNewState(
+  const newState = buildStatusRow(
     BigInt(currentStatuses.toString()),
-    projectIndexes,
-    statusArray
+    statuses
   );
 
   const applicationStatus = {

--- a/test/round/RoundImplementation.test.ts
+++ b/test/round/RoundImplementation.test.ts
@@ -1099,13 +1099,13 @@ describe.only("RoundImplementation", function () {
         let newRow = currentRow;
 
         for (let i = 0; i < statuses.length; i++) {
-          const rowIndex = BigInt(statuses[i].index) * 2n;
+          const columnIndex = BigInt(statuses[i].index) * 2n;
           const status = BigInt(statuses[i].status);
 
           // build a mask and clear the previous status of this index
-          newRow = newRow & ~(3n << rowIndex);
+          newRow = newRow & ~(3n << columnIndex);
           // set the new status
-          newRow = newRow | status << rowIndex;
+          newRow = newRow | status << columnIndex;
         }
 
         return newRow.toString();

--- a/test/round/RoundImplementation.test.ts
+++ b/test/round/RoundImplementation.test.ts
@@ -1124,10 +1124,10 @@ describe.only("RoundImplementation", function () {
         }
 
         const statuses = [
-          {index: 0, status:ApplicationStatus.PENDING},
-          {index: 1, status:ApplicationStatus.ACCEPTED},
-          {index: 2, status:ApplicationStatus.REJECTED},
-          {index: 3, status:ApplicationStatus.CANCELED},
+          { index: 0, status: ApplicationStatus.PENDING },
+          { index: 1, status: ApplicationStatus.ACCEPTED },
+          { index: 2, status: ApplicationStatus.REJECTED },
+          { index: 3, status: ApplicationStatus.CANCELED },
         ];
 
         const newState = buildStatusRow(0n, statuses);

--- a/test/round/RoundImplementation.test.ts
+++ b/test/round/RoundImplementation.test.ts
@@ -6,6 +6,7 @@ import { BytesLike, formatBytes32String, isAddress } from "ethers/lib/utils";
 import { artifacts, ethers, upgrades } from "hardhat";
 import { Artifact } from "hardhat/types";
 import { encodeRoundParameters } from "../../scripts/utils";
+import { buildStatusRow, ApplicationStatus } from "../../utils/applicationStatus";
 import {
   MockERC20,
   MerklePayoutStrategyImplementation,
@@ -20,13 +21,6 @@ import {
 type MetaPtr = {
   protocol: BigNumberish;
   pointer: string;
-};
-
-enum ApplicationStatus  {
-  PENDING = 0,
-  ACCEPTED = 1,
-  REJECTED = 2,
-  CANCELED = 3,
 };
 
 describe.only("RoundImplementation", function () {
@@ -1087,29 +1081,6 @@ describe.only("RoundImplementation", function () {
 
         await initRound(_currentBlockTimestamp);
       });
-
-      const buildStatusRow = (
-        currentRow: bigint,
-        statuses: {index: number, status: ApplicationStatus}[]
-      ) => {
-        if(statuses.length > 128) {
-          throw new Error("Cannot build a status row with more than 128 statuses.");
-        }
-
-        let newRow = currentRow;
-
-        for (let i = 0; i < statuses.length; i++) {
-          const columnIndex = BigInt(statuses[i].index) * 2n;
-          const status = BigInt(statuses[i].status);
-
-          // build a mask and clear the previous status of this index
-          newRow = newRow & ~(3n << columnIndex);
-          // set the new status
-          newRow = newRow | status << columnIndex;
-        }
-
-        return newRow.toString();
-      };
 
       it("SHOULD set the correct application statuses", async () => {
         await ethers.provider.send("evm_mine", [_currentBlockTimestamp + 110]);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es2021",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,

--- a/utils/applicationStatus.ts
+++ b/utils/applicationStatus.ts
@@ -1,0 +1,30 @@
+export enum ApplicationStatus  {
+  PENDING = 0,
+  ACCEPTED = 1,
+  REJECTED = 2,
+  CANCELED = 3,
+};
+
+export function buildStatusRow(
+  currentRow: bigint,
+  statuses: {index: number, status: ApplicationStatus}[]
+) {
+  let newRow = currentRow;
+
+  for (let i = 0; i < statuses.length; i++) {
+    if(statuses[i].index >= 128) {
+      throw new Error(`Status with column index ${statuses[i].index} is out of bounds`);
+    }
+
+    const columnIndex = BigInt(statuses[i].index) * 2n;
+    const status = BigInt(statuses[i].status);
+
+    // build a mask and clear the previous status of this index
+    newRow = newRow & ~(3n << columnIndex);
+    // set the new status
+    newRow = newRow | status << columnIndex;
+  }
+
+  return newRow.toString();
+};
+


### PR DESCRIPTION
This PR cleans up a bit the function that generates a status row in the tests so it can be used for a reference implementation in Javascript.

- The modulo with 32 is not needed, this will cause indexes larger than 32 to overwrite previous statuses
- Error out when passing to many statuses to make it clear that there's a limit

I had to update the TS target to allow usage of BigInt literals.

I apologize if there are formatting issues, I had to disable my formatter, the file is not consistently formatted (mixed single and double quotes, inconsistent spacing) so it was formatting everything.