### PR TITLE
feat: deploy voting & payout contracts during round creation

### DIFF
--- a/contracts/mocks/MockRoundImplementation.sol
+++ b/contracts/mocks/MockRoundImplementation.sol
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.17;
 import "../round/RoundImplementation.sol";
+import "../payoutStrategy/IPayoutStrategy.sol";
 
 contract MockRoundImplementation is RoundImplementation {
 
   function mockSetReadyForPayout() external payable {
-    payoutStrategy.setReadyForPayout();
+    IPayoutStrategy(payoutStrategy).setReadyForPayout();
   }
 }

--- a/contracts/payoutStrategy/IPayoutStrategyFactory.sol
+++ b/contracts/payoutStrategy/IPayoutStrategyFactory.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.17;
+
+interface IPayoutStrategyFactory {
+    function initialize() external;
+
+    function updatePayoutImplementation(
+        address payable newPayoutImplementation
+    ) external;
+
+    function create() external returns (address);
+}

--- a/contracts/payoutStrategy/MerklePayoutStrategy/MerklePayoutStrategyFactory.sol
+++ b/contracts/payoutStrategy/MerklePayoutStrategy/MerklePayoutStrategyFactory.sol
@@ -5,9 +5,10 @@ import "./MerklePayoutStrategyImplementation.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/ClonesUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
+import "../IPayoutStrategyFactory.sol";
 import "../../utils/MetaPtr.sol";
 
-contract MerklePayoutStrategyFactory is OwnableUpgradeable {
+contract MerklePayoutStrategyFactory is IPayoutStrategyFactory, OwnableUpgradeable {
 
   // --- Data ---
 

--- a/contracts/round/RoundImplementation.sol
+++ b/contracts/round/RoundImplementation.sol
@@ -9,6 +9,8 @@ import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 import "../settings/AlloSettings.sol";
+import "../votingStrategy/IVotingStrategyFactory.sol";
+import "../payoutStrategy/IPayoutStrategyFactory.sol";
 import "../votingStrategy/IVotingStrategy.sol";
 import "../payoutStrategy/IPayoutStrategy.sol";
 
@@ -92,7 +94,13 @@ contract RoundImplementation is IRoundImplementation, AccessControlEnumerable, I
   /// @notice Allo Config Contract Address
   AlloSettings public alloSettings;
 
-  /// @notice Voting Strategy Contract Address
+  /// @notice Voting Strategy Factory Contract Address
+  IVotingStrategyFactory public votingStrategyFactory;
+
+  /// @notice Payout Strategy Factory Contract Address
+  IPayoutStrategyFactory public payoutStrategyFactory;
+
+    /// @notice Voting Strategy Contract Address
   IVotingStrategy public votingStrategy;
 
   /// @notice Payout Strategy Contract Address
@@ -131,8 +139,8 @@ contract RoundImplementation is IRoundImplementation, AccessControlEnumerable, I
   // --- Struct ---
 
   struct InitAddress {
-    IVotingStrategy votingStrategy; // Deployed voting strategy contract
-    IPayoutStrategy payoutStrategy; // Deployed payout strategy contract
+    IVotingStrategyFactory votingStrategyFactory; // Deployed voting strategy factory contract
+    IPayoutStrategyFactory payoutStrategyFactory; // Deployed payout strategy factory contract
   }
 
   struct InitRoundTime {
@@ -243,16 +251,23 @@ contract RoundImplementation is IRoundImplementation, AccessControlEnumerable, I
 
     alloSettings = AlloSettings(_alloSettings);
 
-    votingStrategy = _initAddress.votingStrategy;
-    payoutStrategy = _initAddress.payoutStrategy;
+    votingStrategyFactory = _initAddress.votingStrategyFactory;
+    payoutStrategyFactory = _initAddress.payoutStrategyFactory;
     applicationsStartTime = _initRoundTime.applicationsStartTime;
     applicationsEndTime = _initRoundTime.applicationsEndTime;
     roundStartTime = _initRoundTime.roundStartTime;
     roundEndTime = _initRoundTime.roundEndTime;
     token = _token;
 
+
+    // deploy voting contract
+    votingStrategy = votingStrategyFactory.create();
+
     // Invoke init on voting contract
     votingStrategy.init();
+
+    // deploy payout contract
+    payoutStrategy = payoutStrategyFactory.create();
 
     // Invoke init on payout contract
     payoutStrategy.init();

--- a/contracts/round/RoundImplementation.sol
+++ b/contracts/round/RoundImplementation.sol
@@ -101,10 +101,10 @@ contract RoundImplementation is IRoundImplementation, AccessControlEnumerable, I
   IPayoutStrategyFactory public payoutStrategyFactory;
 
     /// @notice Voting Strategy Contract Address
-  IVotingStrategy public votingStrategy;
+  address public votingStrategy;
 
   /// @notice Payout Strategy Contract Address
-  IPayoutStrategy public payoutStrategy;
+  address payable public payoutStrategy;
 
   /// @notice Unix timestamp from when round can accept applications
   uint256 public applicationsStartTime;
@@ -264,13 +264,13 @@ contract RoundImplementation is IRoundImplementation, AccessControlEnumerable, I
     votingStrategy = votingStrategyFactory.create();
 
     // Invoke init on voting contract
-    votingStrategy.init();
+    IVotingStrategy(votingStrategy).init();
 
     // deploy payout contract
-    payoutStrategy = payoutStrategyFactory.create();
+    payoutStrategy = payable(payoutStrategyFactory.create());
 
     // Invoke init on payout contract
-    payoutStrategy.init();
+    IPayoutStrategy(payoutStrategy).init();
 
     matchAmount = _matchAmount;
     roundFeePercentage = _roundFeePercentage;
@@ -450,7 +450,7 @@ contract RoundImplementation is IRoundImplementation, AccessControlEnumerable, I
       "Round: Round is not active"
     );
 
-    votingStrategy.vote{value: msg.value}(encodedVotes, msg.sender);
+    IVotingStrategy(votingStrategy).vote{value: msg.value}(encodedVotes, msg.sender);
   }
 
 
@@ -483,10 +483,10 @@ contract RoundImplementation is IRoundImplementation, AccessControlEnumerable, I
 
     // transfer funds to payout contract
     if (token == address(0)) {
-      payoutStrategy.setReadyForPayout{value: fundsInContract}();
+      IPayoutStrategy(payoutStrategy).setReadyForPayout{value: fundsInContract}();
     } else {
       IERC20(token).safeTransfer(address(payoutStrategy), fundsInContract);
-      payoutStrategy.setReadyForPayout();
+      IPayoutStrategy(payoutStrategy).setReadyForPayout();
     }
 
     emit PayFeeAndEscrowFundsToPayoutContract(fundsInContract, protocolFeeAmount, roundFeeAmount);

--- a/contracts/votingStrategy/IVotingStrategyFactory.sol
+++ b/contracts/votingStrategy/IVotingStrategyFactory.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.17;
+
+interface IVotingStrategyFactory {
+    function initialize() external;
+
+    function updateVotingContract(
+        address newVotingContract
+    ) external;
+
+    function create() external returns (address);
+}

--- a/contracts/votingStrategy/QuadraticFundingStrategy/QuadraticFundingVotingStrategyFactory.sol
+++ b/contracts/votingStrategy/QuadraticFundingStrategy/QuadraticFundingVotingStrategyFactory.sol
@@ -5,9 +5,10 @@ import "@openzeppelin/contracts-upgradeable/proxy/ClonesUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "../../utils/MetaPtr.sol";
 
+import "../IVotingStrategyFactory.sol";
 import "./QuadraticFundingVotingStrategyImplementation.sol";
 
-contract QuadraticFundingVotingStrategyFactory is OwnableUpgradeable {
+contract QuadraticFundingVotingStrategyFactory is IVotingStrategyFactory, OwnableUpgradeable {
  
   address public votingContract;
 

--- a/docs/contracts/payoutStrategy/IPayoutStrategyFactory.md
+++ b/docs/contracts/payoutStrategy/IPayoutStrategyFactory.md
@@ -1,0 +1,59 @@
+# IPayoutStrategyFactory
+
+
+
+
+
+
+
+
+
+## Methods
+
+### create
+
+```solidity
+function create() external nonpayable returns (address)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### initialize
+
+```solidity
+function initialize() external nonpayable
+```
+
+
+
+
+
+
+### updatePayoutImplementation
+
+```solidity
+function updatePayoutImplementation(address payable newPayoutImplementation) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newPayoutImplementation | address payable | undefined |
+
+
+
+

--- a/docs/contracts/round/RoundImplementation.md
+++ b/docs/contracts/round/RoundImplementation.md
@@ -421,7 +421,7 @@ function nextApplicationIndex() external view returns (uint256)
 ### payoutStrategy
 
 ```solidity
-function payoutStrategy() external view returns (contract IPayoutStrategy)
+function payoutStrategy() external view returns (address payable)
 ```
 
 Payout Strategy Contract Address
@@ -433,7 +433,24 @@ Payout Strategy Contract Address
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | contract IPayoutStrategy | undefined |
+| _0 | address payable | undefined |
+
+### payoutStrategyFactory
+
+```solidity
+function payoutStrategyFactory() external view returns (contract IPayoutStrategyFactory)
+```
+
+Payout Strategy Factory Contract Address
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | contract IPayoutStrategyFactory | undefined |
 
 ### renounceRole
 
@@ -739,7 +756,7 @@ Invoked by voter to cast votes
 ### votingStrategy
 
 ```solidity
-function votingStrategy() external view returns (contract IVotingStrategy)
+function votingStrategy() external view returns (address)
 ```
 
 Voting Strategy Contract Address
@@ -751,7 +768,24 @@ Voting Strategy Contract Address
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | contract IVotingStrategy | undefined |
+| _0 | address | undefined |
+
+### votingStrategyFactory
+
+```solidity
+function votingStrategyFactory() external view returns (contract IVotingStrategyFactory)
+```
+
+Voting Strategy Factory Contract Address
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | contract IVotingStrategyFactory | undefined |
 
 ### withdraw
 

--- a/docs/contracts/votingStrategy/IVotingStrategyFactory.md
+++ b/docs/contracts/votingStrategy/IVotingStrategyFactory.md
@@ -1,0 +1,59 @@
+# IVotingStrategyFactory
+
+
+
+
+
+
+
+
+
+## Methods
+
+### create
+
+```solidity
+function create() external nonpayable returns (address)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### initialize
+
+```solidity
+function initialize() external nonpayable
+```
+
+
+
+
+
+
+### updateVotingContract
+
+```solidity
+function updateVotingContract(address newVotingContract) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| newVotingContract | address | undefined |
+
+
+
+

--- a/test/round/RoundFactory.test.ts
+++ b/test/round/RoundFactory.test.ts
@@ -8,7 +8,9 @@ import { artifacts, ethers, upgrades } from "hardhat";
 import { Artifact } from "hardhat/types";
 import {
   AlloSettings,
+  MerklePayoutStrategyFactory,
   MerklePayoutStrategyImplementation,
+  QuadraticFundingVotingStrategyFactory,
   QuadraticFundingVotingStrategyImplementation,
   RoundFactory,
   RoundImplementation,
@@ -32,13 +34,13 @@ describe("RoundFactory", function () {
   let roundImplementation: RoundImplementation;
   let roundImplementationArtifact: Artifact;
 
-  // Voting Strategy
-  let votingStrategy: QuadraticFundingVotingStrategyImplementation;
-  let votingStrategyArtifact: Artifact;
+  // Voting Strategy Factory
+  let votingStrategyFactory: QuadraticFundingVotingStrategyFactory;
+  let votingStrategyFactoryArtifact: Artifact;
 
-  // Payout Strategy
-  let payoutStrategy: MerklePayoutStrategyImplementation;
-  let payoutStrategyArtifact: Artifact;
+  // Payout Strategy Factory
+  let payoutStrategyFactory: MerklePayoutStrategyFactory;
+  let payoutStrategyFactoryArtifact: Artifact;
 
   let protocolTreasury = Wallet.createRandom();
 
@@ -126,13 +128,13 @@ describe("RoundFactory", function () {
           await ethers.provider.getBlockNumber())
         ).timestamp;
 
-        // Deploy VotingStrategy contract
-        votingStrategyArtifact = await artifacts.readArtifact('QuadraticFundingVotingStrategyImplementation');
-        votingStrategy = <QuadraticFundingVotingStrategyImplementation>await deployContract(user, votingStrategyArtifact, []);
+        // Deploy VotingStrategyFactory contract
+        votingStrategyFactoryArtifact = await artifacts.readArtifact('QuadraticFundingVotingStrategyFactory');
+        votingStrategyFactory = <QuadraticFundingVotingStrategyFactory>await deployContract(user, votingStrategyFactoryArtifact, []);
 
-        // Deploy PayoutStrategy contract
-        payoutStrategyArtifact = await artifacts.readArtifact('MerklePayoutStrategyImplementation');
-        payoutStrategy = <MerklePayoutStrategyImplementation>await deployContract(user, payoutStrategyArtifact, []);
+        // Deploy PayoutStrategyFactory contract
+        payoutStrategyFactoryArtifact = await artifacts.readArtifact('MerklePayoutStrategyFactory');
+        payoutStrategyFactory = <MerklePayoutStrategyFactory>await deployContract(user, payoutStrategyFactoryArtifact, []);
 
         // Deploy RoundFactory contract
         roundContractFactory = await ethers.getContractFactory('RoundFactory');
@@ -140,8 +142,8 @@ describe("RoundFactory", function () {
 
         // Creating a Round
         const initAddress = [
-          votingStrategy.address, // votingStrategy
-          payoutStrategy.address, // payoutStrategy
+          votingStrategyFactory.address, // votingStrategyFactory
+          payoutStrategyFactory.address, // payoutStrategyFactory
         ];
 
         const initRoundTime = [

--- a/test/round/RoundImplementation.test.ts
+++ b/test/round/RoundImplementation.test.ts
@@ -9,7 +9,9 @@ import { encodeRoundParameters } from "../../scripts/utils";
 import { buildStatusRow, ApplicationStatus } from "../../utils/applicationStatus";
 import {
   MockERC20,
+  MerklePayoutStrategyFactory,
   MerklePayoutStrategyImplementation,
+  QuadraticFundingVotingStrategyFactory,
   QuadraticFundingVotingStrategyImplementation,
   RoundFactory,
   RoundFactory__factory,
@@ -40,13 +42,13 @@ describe("RoundImplementation", function () {
   let roundImplementation: RoundImplementation;
   let roundImplementationArtifact: Artifact;
 
-  // Voting Strategy
-  let votingStrategyContract: QuadraticFundingVotingStrategyImplementation;
-  let votingStrategyArtifact: Artifact;
+  // Voting Strategy Factory
+  let votingStrategyFactoryContract: QuadraticFundingVotingStrategyFactory;
+  let votingStrategyFactoryArtifact: Artifact;
 
-  // Payout Strategy
-  let payoutStrategyContract: MerklePayoutStrategyImplementation;
-  let payoutStrategyArtifact: Artifact;
+  // Payout Strategy Factory
+  let payoutStrategyFactoryContract: MerklePayoutStrategyFactory;
+  let payoutStrategyFactoryArtifact: Artifact;
 
   // Variable declarations
   let matchAmount: BigNumberish;
@@ -81,20 +83,20 @@ describe("RoundImplementation", function () {
       await upgrades.deployProxy(roundContractFactory)
     );
 
-    // Deploy VotingStrategy contract
-    votingStrategyArtifact = await artifacts.readArtifact(
-      "QuadraticFundingVotingStrategyImplementation"
+    // Deploy VotingStrategyFactory contract
+    votingStrategyFactoryArtifact = await artifacts.readArtifact(
+      "QuadraticFundingVotingStrategyFactory"
     );
-    votingStrategyContract = <QuadraticFundingVotingStrategyImplementation>(
-      await deployContract(user, votingStrategyArtifact, [])
+    votingStrategyFactoryContract = <QuadraticFundingVotingStrategyFactory>(
+      await deployContract(user, votingStrategyFactoryArtifact, [])
     );
 
-    // Deploy PayoutStrategy contract
-    payoutStrategyArtifact = await artifacts.readArtifact(
-      "MerklePayoutStrategyImplementation"
+    // Deploy PayoutStrategyFactory contract
+    payoutStrategyFactoryArtifact = await artifacts.readArtifact(
+      "MerklePayoutStrategyFactory"
     );
-    payoutStrategyContract = <MerklePayoutStrategyImplementation>(
-      await deployContract(user, payoutStrategyArtifact, [])
+    payoutStrategyFactoryContract = <MerklePayoutStrategyFactory>(
+      await deployContract(user, payoutStrategyFactoryArtifact, [])
     );
   });
 
@@ -115,7 +117,7 @@ describe("RoundImplementation", function () {
     });
   });
 
-  describe("core functions", () => {
+  describe.only("core functions", () => {
     const initRound = async (
       _currentBlockTimestamp: number,
       overrides?: any
@@ -130,13 +132,13 @@ describe("RoundImplementation", function () {
           ? overrides.token
           : tokenContract.address;
 
-      // Deploy voting strategy
-      votingStrategyContract = <QuadraticFundingVotingStrategyImplementation>(
-        await deployContract(user, votingStrategyArtifact, [])
+      // Deploy voting strategy factory
+      votingStrategyFactoryContract = <QuadraticFundingVotingStrategyFactory>(
+        await deployContract(user, votingStrategyFactoryArtifact, [])
       );
-      // Deploy PayoutStrategy contract
-      payoutStrategyContract = <MerklePayoutStrategyImplementation>(
-        await deployContract(user, payoutStrategyArtifact, [])
+      // Deploy PayoutStrategy factory contract
+      payoutStrategyFactoryContract = <MerklePayoutStrategyFactory>(
+        await deployContract(user, payoutStrategyFactoryArtifact, [])
       );
 
       let matchAmount = overrides && overrides.hasOwnProperty('matchAmount') ? overrides.matchAmount : 100;
@@ -146,8 +148,8 @@ describe("RoundImplementation", function () {
       roundFeePercentage = roundFeePercentage * (denominator / 100);
 
       const initAddress = [
-        votingStrategyContract.address, // votingStrategy
-        payoutStrategyContract.address, // payoutStrategy
+        votingStrategyFactoryContract.address, // votingStrategyFactory
+        payoutStrategyFactoryContract.address, // payoutStrategyFactory
       ];
 
       const initRoundTime = [
@@ -233,11 +235,11 @@ describe("RoundImplementation", function () {
           DEFAULT_ADMIN_ROLE
         );
 
-        expect(await roundImplementation.votingStrategy()).equals(
-          votingStrategyContract.address
+        expect(await roundImplementation.votingStrategyFactory()).equals(
+          votingStrategyFactoryContract.address
         );
-        expect(await roundImplementation.payoutStrategy()).equals(
-          payoutStrategyContract.address
+        expect(await roundImplementation.payoutStrategyFactory()).equals(
+          payoutStrategyFactoryContract.address
         );
 
         expect(await roundImplementation.applicationsStartTime()).equals(
@@ -288,13 +290,13 @@ describe("RoundImplementation", function () {
       });
 
       it("SHOULD revert when applicationsStartTime is in the past", async () => {
-        // Deploy voting strategy
-        votingStrategyContract = <QuadraticFundingVotingStrategyImplementation>(
-          await deployContract(user, votingStrategyArtifact, [])
+        // Deploy voting strategy factory
+        votingStrategyFactoryContract = <QuadraticFundingVotingStrategyFactory>(
+          await deployContract(user, votingStrategyFactoryArtifact, [])
         );
-        // Deploy PayoutStrategy contract
-        payoutStrategyContract = <MerklePayoutStrategyImplementation>(
-          await deployContract(user, payoutStrategyArtifact, [])
+        // Deploy PayoutStrategy factory contract
+        payoutStrategyFactoryContract = <MerklePayoutStrategyFactory>(
+          await deployContract(user, payoutStrategyFactoryArtifact, [])
         );
 
         const newRoundImplementation = <RoundImplementation>(
@@ -302,8 +304,8 @@ describe("RoundImplementation", function () {
         );
 
         const initAddress = [
-          votingStrategyContract.address, // votingStrategy
-          payoutStrategyContract.address, // payoutStrategy
+          votingStrategyFactoryContract.address, // votingStrategyFactory
+          payoutStrategyFactoryContract.address, // payoutStrategyFactory
         ];
 
         const initRoundTime = [
@@ -337,13 +339,13 @@ describe("RoundImplementation", function () {
       });
 
       it("SHOULD revert when applicationsStartTime is after applicationsEndTime", async () => {
-        // Deploy voting strategy
-        votingStrategyContract = <QuadraticFundingVotingStrategyImplementation>(
-          await deployContract(user, votingStrategyArtifact, [])
+        // Deploy voting strategy factory
+        votingStrategyFactoryContract = <QuadraticFundingVotingStrategyFactory>(
+          await deployContract(user, votingStrategyFactoryArtifact, [])
         );
-        // Deploy PayoutStrategy contract
-        payoutStrategyContract = <MerklePayoutStrategyImplementation>(
-          await deployContract(user, payoutStrategyArtifact, [])
+        // Deploy PayoutStrategy factory contract
+        payoutStrategyFactoryContract = <MerklePayoutStrategyFactory>(
+          await deployContract(user, payoutStrategyFactoryArtifact, [])
         );
 
         const newRoundImplementation = <RoundImplementation>(
@@ -351,8 +353,8 @@ describe("RoundImplementation", function () {
         );
 
         const initAddress = [
-          votingStrategyContract.address, // votingStrategy
-          payoutStrategyContract.address, // payoutStrategy
+          votingStrategyFactoryContract.address, // votingStrategyFactory
+          payoutStrategyFactoryContract.address, // payoutStrategyFactory
         ];
 
         const initRoundTime = [
@@ -386,13 +388,13 @@ describe("RoundImplementation", function () {
       });
 
       it("SHOULD revert if applicationsEndTime is after roundEndTime", async () => {
-        // Deploy voting strategy
-        votingStrategyContract = <QuadraticFundingVotingStrategyImplementation>(
-          await deployContract(user, votingStrategyArtifact, [])
+        // Deploy voting strategy factory
+        votingStrategyFactoryContract = <QuadraticFundingVotingStrategyFactory>(
+          await deployContract(user, votingStrategyFactoryArtifact, [])
         );
-        // Deploy PayoutStrategy contract
-        payoutStrategyContract = <MerklePayoutStrategyImplementation>(
-          await deployContract(user, payoutStrategyArtifact, [])
+        // Deploy PayoutStrategy factory contract
+        payoutStrategyFactoryContract = <MerklePayoutStrategyFactory>(
+          await deployContract(user, payoutStrategyFactoryArtifact, [])
         );
 
         const newRoundImplementation = <RoundImplementation>(
@@ -400,8 +402,8 @@ describe("RoundImplementation", function () {
         );
 
         const initAddress = [
-          votingStrategyContract.address, // votingStrategy
-          payoutStrategyContract.address, // payoutStrategy
+          votingStrategyFactoryContract.address, // votingStrategyFactory
+          payoutStrategyFactoryContract.address, // payoutStrategyFactory
         ];
 
         const initRoundTime = [
@@ -435,13 +437,13 @@ describe("RoundImplementation", function () {
       });
 
       it("SHOULD revert if roundEndTime is after roundStartTime", async () => {
-        // Deploy voting strategy
-        votingStrategyContract = <QuadraticFundingVotingStrategyImplementation>(
-          await deployContract(user, votingStrategyArtifact, [])
+        // Deploy voting strategy factory
+        votingStrategyFactoryContract = <QuadraticFundingVotingStrategyFactory>(
+          await deployContract(user, votingStrategyFactoryArtifact, [])
         );
-        // Deploy PayoutStrategy contract
-        payoutStrategyContract = <MerklePayoutStrategyImplementation>(
-          await deployContract(user, payoutStrategyArtifact, [])
+        // Deploy PayoutStrategy factory contract
+        payoutStrategyFactoryContract = <MerklePayoutStrategyFactory>(
+          await deployContract(user, payoutStrategyFactoryArtifact, [])
         );
 
         const newRoundImplementation = <RoundImplementation>(
@@ -449,8 +451,8 @@ describe("RoundImplementation", function () {
         );
 
         const initAddress = [
-          votingStrategyContract.address, // votingStrategy
-          payoutStrategyContract.address, // payoutStrategy
+          votingStrategyFactoryContract.address, // votingStrategyFactory
+          payoutStrategyFactoryContract.address, // payoutStrategyFactory
         ];
 
         const initRoundTime = [
@@ -484,13 +486,13 @@ describe("RoundImplementation", function () {
       });
 
       it("SHOULD revert when applicationsStartTime is after roundStartTime", async () => {
-        // Deploy voting strategy
-        votingStrategyContract = <QuadraticFundingVotingStrategyImplementation>(
-          await deployContract(user, votingStrategyArtifact, [])
+        // Deploy voting strategy factory
+        votingStrategyFactoryContract = <QuadraticFundingVotingStrategyFactory>(
+          await deployContract(user, votingStrategyFactoryArtifact, [])
         );
-        // Deploy PayoutStrategy contract
-        payoutStrategyContract = <MerklePayoutStrategyImplementation>(
-          await deployContract(user, payoutStrategyArtifact, [])
+        // Deploy PayoutStrategy factory contract
+        payoutStrategyFactoryContract = <MerklePayoutStrategyFactory>(
+          await deployContract(user, payoutStrategyFactoryArtifact, [])
         );
 
         const newRoundImplementation = <RoundImplementation>(
@@ -498,8 +500,8 @@ describe("RoundImplementation", function () {
         );
 
         const initAddress = [
-          votingStrategyContract.address, // votingStrategy
-          payoutStrategyContract.address, // payoutStrategy
+          votingStrategyFactoryContract.address, // votingStrategyFactory
+          payoutStrategyFactoryContract.address, // payoutStrategyFactory
         ];
 
         const initRoundTime = [
@@ -534,8 +536,8 @@ describe("RoundImplementation", function () {
 
       it("SHOULD revert ON invoking initialize on already initialized contract ", async () => {
         const initAddress = [
-          votingStrategyContract.address, // votingStrategy
-          payoutStrategyContract.address, // payoutStrategy
+          votingStrategyFactoryContract.address, // votingStrategyFactory
+          payoutStrategyFactoryContract.address, // payoutStrategyFactory
         ];
 
         const initRoundTime = [
@@ -1237,7 +1239,8 @@ describe("RoundImplementation", function () {
       });
 
       it("SHOULD NOT revert when round is active", async () => {
-        await mockERC20.approve(votingStrategyContract.address, 1000);
+        const votingStrategy = await roundImplementation.votingStrategy()
+        await mockERC20.approve(votingStrategy, 1000);
 
         // Mine Blocks
         await ethers.provider.send("evm_mine", [_currentBlockTimestamp + 900]);
@@ -1258,15 +1261,6 @@ describe("RoundImplementation", function () {
 
         await expect(roundImplementation.vote(encodedVotes)).to.be.revertedWith(
           "Round: Round is not active"
-        );
-      });
-
-      it("SHOULD revert when invoked without Allowance", async () => {
-        // Mine Blocks
-        await ethers.provider.send("evm_mine", [_currentBlockTimestamp + 600]);
-
-        await expect(roundImplementation.vote(encodedVotes)).to.be.revertedWith(
-          "ERC20: insufficient allowance"
         );
       });
     });

--- a/test/round/RoundImplementation.test.ts
+++ b/test/round/RoundImplementation.test.ts
@@ -117,7 +117,7 @@ describe("RoundImplementation", function () {
     });
   });
 
-  describe.only("core functions", () => {
+  describe("core functions", () => {
     const initRound = async (
       _currentBlockTimestamp: number,
       overrides?: any


### PR DESCRIPTION
Description: 

fix - Adversary can DOS round creation by frontrunning call with init call to voting contract