### PR TITLE
Update `IPayoutStrategy` to not assume off chain distribution calculations

### DIFF
--- a/contracts/payoutStrategy/IPayoutStrategy.sol
+++ b/contracts/payoutStrategy/IPayoutStrategy.sol
@@ -36,9 +36,6 @@ abstract contract IPayoutStrategy {
 
   // --- Event ---
 
-  /// @notice Emitted when funds are withdrawn from the payout contract
-  event FundsWithdrawn(address indexed tokenAddress, uint256 amount, address withdrawAddress);
-
   /// @notice Emitted when contract is ready for payout
   event ReadyForPayout();
 

--- a/contracts/payoutStrategy/IPayoutStrategy.sol
+++ b/contracts/payoutStrategy/IPayoutStrategy.sol
@@ -1,31 +1,22 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.17;
 
-import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import "../utils/MetaPtr.sol";
-
 import "../round/RoundImplementation.sol";
 
 /**
  * @notice Defines the abstract contract for payout strategies
  * for a round. Any new payout strategy would be expected to
  * extend this abstract contract.
+ *
  * Every PayoutStrategyImplementation contract would be unique to RoundImplementation
  * and would be deployed before creating a round.
- *
- * Functions that are marked as `virtual` are expected to be overridden
- * by the implementation contract.
- *
- * - updateDistribution
- * - payout
  *
  * @dev
  *  - Deployed before creating a round
  *  - Funds are transferred to the payout contract from round only during payout
  */
 abstract contract IPayoutStrategy {
-
-  using SafeERC20Upgradeable for IERC20Upgradeable;
 
   // --- Constants ---
 
@@ -39,9 +30,6 @@ abstract contract IPayoutStrategy {
 
   /// @notice Token address
   address public tokenAddress;
-
-  /// MetaPtr containing the distribution
-  MetaPtr public distributionMetaPtr;
 
   // @notice
   bool public isReadyForPayout;
@@ -79,14 +67,13 @@ abstract contract IPayoutStrategy {
     _;
   }
 
-  // --- Core methods ---
+  // --- Core Methods ---
 
   /**
    * @notice Invoked by RoundImplementation on creation to
    * set the round for which the payout strategy is to be used
-   *
    */
-  function init() external {
+  function init() external virtual {
     require(roundAddress == address(0x0), "roundAddress already set");
     roundAddress = payable(msg.sender);
 
@@ -96,71 +83,13 @@ abstract contract IPayoutStrategy {
     isReadyForPayout = false;
   }
 
-  /**s
-   * @notice Invoked by RoundImplementation to upload distribution to the
-   * payout strategy
-   *
-   * @dev
-   * - ideally IPayoutStrategy implementation should emit events after
-   *   distribution is updated
-   * - would be invoked at the end of the round
-   *
-   * Modifiers:
-   *  - isRoundOperator
-   *  - roundHasEnded
-   *
-   * @param _encodedDistribution encoded distribution
-   */
-  function updateDistribution(bytes calldata _encodedDistribution) external virtual;
-
-  /// @notice checks that distribution is set before setReadyForPayout
-  function isDistributionSet() public virtual view returns (bool);
-
   /// @notice Invoked by RoundImplementation to set isReadyForPayout
-  function setReadyForPayout() external payable isRoundContract roundHasEnded {
+  /// @dev Can only be called once and (by default) cannot be changed once called
+  function setReadyForPayout() virtual external payable isRoundContract roundHasEnded {
     require(isReadyForPayout == false, "isReadyForPayout already set");
-    require(isDistributionSet(), "distribution not set");
 
     isReadyForPayout = true;
     emit ReadyForPayout();
-  }
-
-  /**
-   * @notice Invoked by RoundImplementation to withdraw funds to
-   * withdrawAddress from the payout contract
-   *
-   * @param withdrawAddress withdraw funds address
-   */
-  function withdrawFunds(address payable withdrawAddress) external payable virtual isRoundOperator roundHasEnded {
-
-    uint balance = _getTokenBalance();
-
-    if (tokenAddress == address(0)) {
-      /// @dev native token
-      AddressUpgradeable.sendValue(
-        withdrawAddress,
-        balance
-      );
-    } else {
-      /// @dev ERC20 token
-      IERC20Upgradeable(tokenAddress).safeTransfer(
-        withdrawAddress,
-        balance
-      );
-    }
-
-    emit FundsWithdrawn(tokenAddress, balance, withdrawAddress);
-  }
-
-  /**
-   * Util function to get token balance in the contract
-   */
-  function _getTokenBalance() internal view returns (uint) {
-    if (tokenAddress == address(0)) {
-      return address(this).balance;
-    } else {
-      return IERC20Upgradeable(tokenAddress).balanceOf(address(this));
-    }
   }
 
   receive() external payable {}

--- a/contracts/payoutStrategy/MerklePayoutStrategy/MerklePayoutStrategyImplementation.sol
+++ b/contracts/payoutStrategy/MerklePayoutStrategy/MerklePayoutStrategyImplementation.sol
@@ -34,6 +34,9 @@ contract MerklePayoutStrategyImplementation is IPayoutStrategy, Initializable {
 
   // --- Events ---
 
+  /// @notice Emitted when funds are withdrawn from the payout contract
+  event FundsWithdrawn(address indexed tokenAddress, uint256 amount, address withdrawAddress);
+
   /// @notice Emitted when the distribution is updated
   event DistributionUpdated(bytes32 merkleRoot, MetaPtr distributionMetaPtr);
 

--- a/contracts/payoutStrategy/MerklePayoutStrategy/MerklePayoutStrategyImplementation.sol
+++ b/contracts/payoutStrategy/MerklePayoutStrategy/MerklePayoutStrategyImplementation.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.17;
 
+import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
@@ -14,6 +15,8 @@ import "../IPayoutStrategy.sol";
  */
 contract MerklePayoutStrategyImplementation is IPayoutStrategy, Initializable {
 
+  using SafeERC20Upgradeable for IERC20Upgradeable;
+
   string public constant VERSION = "0.2.0";
 
   using SafeERC20 for IERC20;
@@ -25,6 +28,9 @@ contract MerklePayoutStrategyImplementation is IPayoutStrategy, Initializable {
 
   /// @notice packed array of booleans to keep track of claims
   mapping(uint256 => uint256) private distributedBitMap;
+
+  /// MetaPtr containing the distribution
+  MetaPtr public distributionMetaPtr;
 
   // --- Events ---
 
@@ -51,6 +57,7 @@ contract MerklePayoutStrategyImplementation is IPayoutStrategy, Initializable {
     bytes32 projectId;
   }
 
+  // @NOTE: we need this because we're inheriting from Initializable.sol
   function initialize() external initializer {
     // empty initializer
   }
@@ -59,7 +66,7 @@ contract MerklePayoutStrategyImplementation is IPayoutStrategy, Initializable {
 
   /// @notice Invoked by round operator to update the merkle root and distribution MetaPtr
   /// @param encodedDistribution encoded distribution
-  function updateDistribution(bytes calldata encodedDistribution) external override roundHasEnded isRoundOperator {
+  function updateDistribution(bytes calldata encodedDistribution) external roundHasEnded isRoundOperator {
 
     require(isReadyForPayout == false, "Payout: Already ready for payout");
 
@@ -75,8 +82,17 @@ contract MerklePayoutStrategyImplementation is IPayoutStrategy, Initializable {
   }
 
   /// @notice function to check if distribution is set
-  function isDistributionSet() public view override returns (bool) {
+  function isDistributionSet() public view returns (bool) {
     return merkleRoot != "";
+  }
+
+  /// @notice Invoked by RoundImplementation to set isReadyForPayout
+  function setReadyForPayout() override external payable isRoundContract roundHasEnded {
+    require(isReadyForPayout == false, "isReadyForPayout already set");
+    require(isDistributionSet(), "distribution not set");
+
+    isReadyForPayout = true;
+    emit ReadyForPayout();
   }
 
   /// @notice Util function to check if distribution is done
@@ -91,11 +107,37 @@ contract MerklePayoutStrategyImplementation is IPayoutStrategy, Initializable {
     return distributedWord & mask == mask;
   }
 
+  /**
+   * @notice Invoked by RoundImplementation to withdraw funds to
+   * withdrawAddress from the payout contract
+   *
+   * @param withdrawAddress withdraw funds address
+   */
+  function withdrawFunds(address payable withdrawAddress) external payable isRoundOperator roundHasEnded {
+
+    uint balance = _getTokenBalance();
+
+    if (tokenAddress == address(0)) {
+      /// @dev native token
+      AddressUpgradeable.sendValue(
+        withdrawAddress,
+        balance
+      );
+    } else {
+      /// @dev ERC20 token
+      IERC20Upgradeable(tokenAddress).safeTransfer(
+        withdrawAddress,
+        balance
+      );
+    }
+
+    emit FundsWithdrawn(tokenAddress, balance, withdrawAddress);
+  }
 
   /// @notice function to distribute funds to recipient
   /// @dev can be invoked only by round operator
   /// @param _distributions encoded distribution
-  function payout(Distribution[] calldata _distributions) external virtual payable isRoundOperator {
+  function payout(Distribution[] calldata _distributions) external payable isRoundOperator {
     require(isReadyForPayout == true, "Payout: Not ready for payout");
 
     for (uint256 i = 0; i < _distributions.length; ++i) {
@@ -149,6 +191,17 @@ contract MerklePayoutStrategyImplementation is IPayoutStrategy, Initializable {
       Address.sendValue(_recipient, _amount);
     } else {
       IERC20(tokenAddress).safeTransfer(_recipient, _amount);
+    }
+  }
+
+  /**
+   * Util function to get token balance in the contract
+   */
+  function _getTokenBalance() internal view returns (uint) {
+    if (tokenAddress == address(0)) {
+      return address(this).balance;
+    } else {
+      return IERC20Upgradeable(tokenAddress).balanceOf(address(this));
     }
   }
 }

--- a/docs/contracts/payoutStrategy/IPayoutStrategy.md
+++ b/docs/contracts/payoutStrategy/IPayoutStrategy.md
@@ -104,24 +104,6 @@ Token address
 
 ## Events
 
-### FundsWithdrawn
-
-```solidity
-event FundsWithdrawn(address indexed tokenAddress, uint256 amount, address withdrawAddress)
-```
-
-Emitted when funds are withdrawn from the payout contract
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| tokenAddress `indexed` | address | undefined |
-| amount  | uint256 | undefined |
-| withdrawAddress  | address | undefined |
-
 ### ReadyForPayout
 
 ```solidity

--- a/docs/contracts/payoutStrategy/IPayoutStrategy.md
+++ b/docs/contracts/payoutStrategy/IPayoutStrategy.md
@@ -4,7 +4,7 @@
 
 
 
-Defines the abstract contract for payout strategies for a round. Any new payout strategy would be expected to extend this abstract contract. Every PayoutStrategyImplementation contract would be unique to RoundImplementation and would be deployed before creating a round. Functions that are marked as `virtual` are expected to be overridden by the implementation contract. - updateDistribution - payout
+Defines the abstract contract for payout strategies for a round. Any new payout strategy would be expected to extend this abstract contract. Every PayoutStrategyImplementation contract would be unique to RoundImplementation and would be deployed before creating a round.
 
 *- Deployed before creating a round  - Funds are transferred to the payout contract from round only during payout*
 
@@ -27,24 +27,6 @@ round operator role
 |---|---|---|
 | _0 | bytes32 | undefined |
 
-### distributionMetaPtr
-
-```solidity
-function distributionMetaPtr() external view returns (uint256 protocol, string pointer)
-```
-
-MetaPtr containing the distribution
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| protocol | uint256 | undefined |
-| pointer | string | undefined |
-
 ### init
 
 ```solidity
@@ -55,23 +37,6 @@ Invoked by RoundImplementation on creation to set the round for which the payout
 
 
 
-
-### isDistributionSet
-
-```solidity
-function isDistributionSet() external view returns (bool)
-```
-
-checks that distribution is set before setReadyForPayout
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | bool | undefined |
 
 ### isReadyForPayout
 
@@ -115,7 +80,7 @@ function setReadyForPayout() external payable
 
 Invoked by RoundImplementation to set isReadyForPayout
 
-
+*Can only be called once and (by default) cannot be changed once called*
 
 
 ### tokenAddress
@@ -134,38 +99,6 @@ Token address
 | Name | Type | Description |
 |---|---|---|
 | _0 | address | undefined |
-
-### updateDistribution
-
-```solidity
-function updateDistribution(bytes _encodedDistribution) external nonpayable
-```
-
-sInvoked by RoundImplementation to upload distribution to the payout strategy
-
-*- ideally IPayoutStrategy implementation should emit events after   distribution is updated - would be invoked at the end of the round Modifiers:  - isRoundOperator  - roundHasEnded*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| _encodedDistribution | bytes | encoded distribution |
-
-### withdrawFunds
-
-```solidity
-function withdrawFunds(address payable withdrawAddress) external payable
-```
-
-Invoked by RoundImplementation to withdraw funds to withdrawAddress from the payout contract
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| withdrawAddress | address payable | withdraw funds address |
 
 
 


### PR DESCRIPTION
The previous implementation of `IPayoutStrategy` included a few pieces that were
required for how we handle the QF distributions in
`MerklePayoutStrategyImplementation` but were part of the interface. This made
it annoying/difficult to create other kinds of voting strategies where the
payout distribution isn't calculated offchain and uploaded (i.e. simple, direct
payout strategies that look at the onchain voting data to calculate payout).

These methods have been moved into the `MerklePayoutStrategyImplementation`
contract.
